### PR TITLE
For ops works, exchanging $_ENV for getenv();

### DIFF
--- a/lastfm.php
+++ b/lastfm.php
@@ -166,10 +166,10 @@ function getAlbums($url)
 if(!isset($config))
 {
 	//if not defined, use Environment variables
-	$config['bucket'] = $_ENV["bucket"];
-	$config['api_key'] = $_ENV["api_key"];
-	$config['accessKey'] = $_ENV["accessKey"];
-	$config['secretKey'] = $_ENV["secretKey"];
+	$config['bucket'] = getenv("bucket");
+	$config['api_key'] = getenv("api_key");
+	$config['accessKey'] = getenv("accessKey");
+	$config['secretKey'] = getenv("secretKey");
 }
 
 


### PR DESCRIPTION
As described.
Ops works only provides Environment variables into the runtime, leaving $_ENV empty.
getenv works the same, but allows env variables to be injected into the runtime.
